### PR TITLE
Fixed typographical error, changed abreviation to abbreviation in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Suggestions accepted.
 ### Function Names
 * Functions will be provided in camelCaseLikeThis except where it harms readablity or makes no sense.
 * For example km2mi is not benefited by being turned into km2Mi.
-* Abreviations are all uppercase unless they start the function name.  For example aicCompare versus compareAIC.
+* Abbreviations are all uppercase unless they start the function name.  For example aicCompare versus compareAIC.
 * As a general matter, functions will be defined in verb-noun order as in "I want to <verb> <noun>".
 * Nouns for these purposes will remain in their singular form, e.g. compareAIC not compareAICs.
 


### PR DESCRIPTION
drknexus, I've corrected a typographical error in the documentation of the [repsych](https://github.com/drknexus/repsych) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
